### PR TITLE
[16226] Hotfix: CI building

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,14 @@
+breathe==4.31.0
+colcon-common-extensions==0.2.1
+colcon-mixin==0.2.0
 doc8==0.10.1
 docutils==0.16.0
+GitPython==3.1.24
 setuptools==59.4.0
 sphinx_rtd_theme==0.5.2
+sphinx-tabs==3.2.0
 sphinx==4.3.1
 sphinxcontrib-imagehelper==1.1.1
+sphinxcontrib-plantuml==0.22
 sphinxcontrib.spelling==7.2.1
+vcstool==0.3.0


### PR DESCRIPTION
Signed-off-by: JLBuenoLopez-eProsima <joseluisbueno@eprosima.com>

CI build process is failing with the following error:

```
Err:22 http://security.ubuntu.com/ubuntu focal-updates/main amd64 python3-pil amd64 7.0.0-4ubuntu0.5
  404  Not Found [IP: 185.125.190.39 80]
Fetched 7648 kB in 1s (6455 kB/s)
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/p/pillow/python3-pil_7.0.0-4ubuntu0.5_amd64.deb  404  Not Found [IP: 185.125.190.39 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

This PR tries using the same requirements as Fast DDS docs to solve the issue.