### PR TITLE
[17521] Upgrade dependency fixing security vulnerability

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 doc8==0.10.1
 docutils==0.16.0
-setuptools==59.4.0
+setuptools==67.6.0
 sphinx_rtd_theme==0.5.2
 sphinx==4.3.1
 sphinxcontrib-imagehelper==1.1.1


### PR DESCRIPTION
This supersedes #41, bumping to the newest setuptools version.

Documentation has been generated locally and checked that nothing has been broken.