### PR TITLE
[20820] Update mirror job

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,13 +1,12 @@
 # .github/workflows/mirror.yml
+name: Mirror
 on:
   push:
     branches:
       - 'master'
-      - '2.14.x'
 
 jobs:
-  mirror_job_master:
-    if: github.ref == 'refs/heads/master'
+  mirror_job:
     name: Mirror master branch to latest minor branches
     runs-on: ubuntu-latest
     strategy:
@@ -23,22 +22,4 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         source: 'master'
-        dest: ${{ matrix.dest_branch }}
-
-  mirror_job_2_x:
-    if: github.ref == 'refs/heads/2.14.x'
-    name: Mirror 2.14.x branch to latest minor branches
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        dest_branch:
-          - '2.x'
-    steps:
-    - name: Mirror action step
-      id: mirror
-      uses: eProsima/eProsima-CI/external/mirror-branch-action@main
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        source: '2.14.x'
         dest: ${{ matrix.dest_branch }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This pr updates mirror job
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/ShapesDemo#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo docs developers must also refer to the internal Redmine task. -->
- N/A Documentation tests pass locally.
- N/A Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
