### PR TITLE
[21310] Set 2.13.x as EOL

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
     In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
     Please uncomment following line, adjusting the corresponding target branches for the backport.
 -->
-<!-- @Mergifyio backport 2.14.x 2.13.x 2.10.x 2.6.x -->
+<!-- @Mergifyio backport 2.14.x 2.10.x 2.6.x -->
 
 <!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
 <!-- Fixes #(issue) -->

--- a/docs/notes/notes.rst
+++ b/docs/notes/notes.rst
@@ -11,6 +11,7 @@ Previous versions
 .. include:: previous_versions/v2.14.2.rst
 .. include:: previous_versions/v2.14.1.rst
 .. include:: previous_versions/v2.14.0.rst
+.. include:: previous_versions/v2.13.6.rst
 .. include:: previous_versions/v2.13.5.rst
 .. include:: previous_versions/v2.13.4.rst
 .. include:: previous_versions/v2.13.3.rst

--- a/docs/notes/previous_versions/v2.13.0.rst
+++ b/docs/notes/previous_versions/v2.13.0.rst
@@ -1,5 +1,5 @@
-Version 2.13.0
-^^^^^^^^^^^^^^
+Version 2.13.0 (EOL)
+^^^^^^^^^^^^^^^^^^^^
 
 This minor release includes the following **improvements**:
 

--- a/docs/notes/previous_versions/v2.13.1.rst
+++ b/docs/notes/previous_versions/v2.13.1.rst
@@ -1,5 +1,5 @@
-Version 2.13.1
-^^^^^^^^^^^^^^
+Version 2.13.1 (EOL)
+^^^^^^^^^^^^^^^^^^^^
 
 This patch release includes the following **improvements**:
 

--- a/docs/notes/previous_versions/v2.13.2.rst
+++ b/docs/notes/previous_versions/v2.13.2.rst
@@ -1,5 +1,5 @@
-Version 2.13.2
-^^^^^^^^^^^^^^
+Version 2.13.2 (EOL)
+^^^^^^^^^^^^^^^^^^^^
 
 This patch release includes the following **improvements**:
 

--- a/docs/notes/previous_versions/v2.13.3.rst
+++ b/docs/notes/previous_versions/v2.13.3.rst
@@ -1,5 +1,5 @@
-Version 2.13.3
-^^^^^^^^^^^^^^
+Version 2.13.3 (EOL)
+^^^^^^^^^^^^^^^^^^^^
 
 This patch release includes the following **improvements**:
 

--- a/docs/notes/previous_versions/v2.13.4.rst
+++ b/docs/notes/previous_versions/v2.13.4.rst
@@ -1,5 +1,5 @@
-Version 2.13.4
-^^^^^^^^^^^^^^
+Version 2.13.4 (EOL)
+^^^^^^^^^^^^^^^^^^^^
 
 This patch release includes the following **improvements**:
 

--- a/docs/notes/previous_versions/v2.13.6.rst
+++ b/docs/notes/previous_versions/v2.13.6.rst
@@ -1,6 +1,7 @@
-Version 2.13.5 (EOL)
+Version 2.13.6 (EOL)
 ^^^^^^^^^^^^^^^^^^^^
 
 This patch release includes the following **improvements**:
 
-1. Support for Fast DDS v2.13.5
+#. Support for Fast DDS v2.13.6
+#. Improve CI workflows


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR sets 2.13.x as EOL, and includes v2.13.6 release notes
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.14.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/ShapesDemo#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo docs developers must also refer to the internal Redmine task. -->
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
