### PR TITLE
[21783] Add ShapesDemo 3.1.0 release notes

### DIFF
--- a/docs/notes/notes.rst
+++ b/docs/notes/notes.rst
@@ -1,15 +1,14 @@
-Version 3.0.1
+Version 3.1.0
 ==============
 
 This release includes the following **improvements**:
 
-#. Support to Fast DDS v3.0.1.
-#. Update ``eProsima-CI`` action to install ``Qt``
-#. Regenerate types with Fast DDS-Gen v4.0.1
+#. Support to Fast DDS v3.1.0.
 
 Previous versions
 =================
 
+.. include:: previous_versions/v3.0.1.rst
 .. include:: previous_versions/v3.0.0.rst
 .. include:: previous_versions/v2.14.3.rst
 .. include:: previous_versions/v2.14.2.rst

--- a/docs/notes/previous_versions/v3.0.1.rst
+++ b/docs/notes/previous_versions/v3.0.1.rst
@@ -1,0 +1,8 @@
+Version 3.0.1
+^^^^^^^^^^^^^
+
+This release includes the following **improvements**:
+
+#. Support to Fast DDS v3.0.1.
+#. Update ``eProsima-CI`` action to install ``Qt``
+#. Regenerate types with Fast DDS-Gen v4.0.1


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.0.x 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/ShapesDemo#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo docs developers must also refer to the internal Redmine task. -->
- **N/A** Documentation tests pass locally.
- **N/A** Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
