### PR TITLE
Update commertial support section

### DIFF
--- a/docs/02-formalia/titlepage.rst
+++ b/docs/02-formalia/titlepage.rst
@@ -13,3 +13,11 @@ A single instance of the eProsima Shapes Demo can publish on or subscribe to sev
 
 It demonstrates the capabilities of eProsima *Fast DDS* or as a proof of interoperability with other
 RTPS-compliant implementations.
+
+##################
+Commercial support
+##################
+
+Looking for commercial support? Write us to info@eprosima.com
+
+Find more about us at `eProsima's webpage <https://eprosima.com/>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,6 +9,7 @@ eProsima Shapes Demo
    :caption: Installation Manual
    :numbered: 5
    :maxdepth: 2
+   :hidden:
 
    /installation/windows_binaries
    /installation/linux_sources
@@ -20,6 +21,7 @@ eProsima Shapes Demo
    :caption: First Steps
    :numbered: 5
    :maxdepth: 2
+   :hidden:
 
    /first_steps/first_steps
 
@@ -29,6 +31,7 @@ eProsima Shapes Demo
    :caption: Shapes Demo Examples
    :numbered: 5
    :maxdepth: 2
+   :hidden:
 
    /examples/discovery
    /examples/history_durability
@@ -49,6 +52,7 @@ eProsima Shapes Demo
    :caption: Troubleshooting
    :numbered: 5
    :maxdepth: 2
+   :hidden:
 
    /troubleshooting/troubleshooting
    /troubleshooting/interoperability
@@ -58,5 +62,6 @@ eProsima Shapes Demo
 .. toctree::
    :caption: Release Notes
    :maxdepth: 2
+   :hidden:
 
    /notes/notes


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.0.x 2.14.x 2.10.x 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/ShapesDemo#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [ ] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo docs developers must also refer to the internal Redmine task. -->
- [ ] Documentation tests pass locally.
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
