### PR TITLE
[21560] Add 2.14.4 notes

### DIFF
--- a/docs/notes/notes.rst
+++ b/docs/notes/notes.rst
@@ -10,6 +10,7 @@ Previous versions
 
 .. include:: previous_versions/v3.0.1.rst
 .. include:: previous_versions/v3.0.0.rst
+.. include:: previous_versions/v2.14.4.rst
 .. include:: previous_versions/v2.14.3.rst
 .. include:: previous_versions/v2.14.2.rst
 .. include:: previous_versions/v2.14.1.rst

--- a/docs/notes/previous_versions/v2.14.4.rst
+++ b/docs/notes/previous_versions/v2.14.4.rst
@@ -1,0 +1,6 @@
+Version 2.14.4
+^^^^^^^^^^^^^^
+
+This release includes the following **improvements**:
+
+#. Support for Fast DDS v2.14.4


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds the notes from 2.14.4.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.1.x 3.0.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/ShapesDemo#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [X] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo docs developers must also refer to the internal Redmine task. -->
- [X] Documentation tests pass locally.
- [X] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
