### PR TITLE
 Add new commercial message

### DIFF
--- a/docs/02-formalia/titlepage.rst
+++ b/docs/02-formalia/titlepage.rst
@@ -20,7 +20,7 @@ Commercial support
 
 .. |commercial_support_link| raw:: html
 
-   <a href="https://forms.zohopublic.com/reach/form/CommercialSupportRequest/formperma/Ac8GwewD7PTDadQZIV92qDEzNFfMlJnYmA029mSJtJ8" target="_blank" rel="noopener noreferrer">share your details</a>
+   <a href="https://forms.eprosima.com/reach/form/CommercialSupportRequest/formperma/Ac8GwewD7PTDadQZIV92qDEzNFfMlJnYmA029mSJtJ8" target="_blank" rel="noopener noreferrer">share your details</a>
 
 Looking for commercial support? Please |commercial_support_link| so we can assist you.
 

--- a/docs/02-formalia/titlepage.rst
+++ b/docs/02-formalia/titlepage.rst
@@ -18,6 +18,14 @@ RTPS-compliant implementations.
 Commercial support
 ##################
 
-Looking for commercial support? Write us to info@eprosima.com
+.. |commercial_support_link| raw:: html
 
-Find more about us at `eProsima's webpage <https://eprosima.com/>`_.
+   <a href="https://forms.zohopublic.com/reach/form/CommercialSupportRequest/formperma/Ac8GwewD7PTDadQZIV92qDEzNFfMlJnYmA029mSJtJ8" target="_blank" rel="noopener noreferrer">share your details</a>
+
+Looking for commercial support? Please |commercial_support_link| so we can assist you.
+
+.. |eprosima_webpage_link| raw:: html
+
+   <a href="https://www.eprosima.com" target="_blank" rel="noopener noreferrer">eProsima’s webpage</a>
+
+Find more about us at |eprosima_webpage_link|.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,60 +143,51 @@ def retrieve_custom_sidebar(root_dir):
     return ret
 
 
-def download_css(html_css_dir):
+def download_file(url, output_path):
     """
-    Download the common theme of eProsima readthedocs documentation.
-
-    The theme is defined in a CSS file that is hosted in the eProsima GitHub
-    repository with the index of all eProsima product documentation
-    (https://github.com/eProsima/all-docs).
-
-    :param html_css_dir: The directory to save the CSS stylesheet.
-    :return: True if the file was downloaded and generated successfully.
-        False if not.
+    Download a file from a URL to a local path.
+    :param url: The URL of the file to download.
+    :param output_path: The local path where the file will be saved.
+    :return: The path to the file if downloaded successfully, or the path to an empty file otherwise.
     """
-    url = "https://raw.githubusercontent.com/eProsima/all-docs/master/source/_static/css/eprosima-furo.css"
-
     try:
-        req = requests.get(url, allow_redirects=True)
-    except requests.RequestException as e:
-        print(
-            "Failed to download the CSS with the eProsima furo theme."
-            "Request Error: {}".format(e)
-        )
-        return False
-    if req.status_code != 200:
-        print(
-            "Failed to download the CSS with the eProsima furo theme."
-            "Return code: {}".format(req.status_code)
-        )
-        return False
-    os.makedirs(os.path.dirname("{}/_static/css/".format(html_css_dir)), exist_ok=True)
-    theme_path = "{}/_static/css/eprosima-furo.css".format(html_css_dir)
-    with open(theme_path, "wb") as f:
-        try:
+        req = requests.get(url, allow_redirects=True, timeout=10)
+        req.raise_for_status()  # Raise an error for bad responses
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "wb") as f:
             f.write(req.content)
-        except OSError:
-            print("Failed to create the file: {}".format(theme_path))
-            return False
-    return True
+        return output_path
+    except requests.RequestException as e:
+        print(f"Failed to download the file from {url}. Request Error: {e}")
+    except OSError as e:
+        print(f"Failed to create the file at {output_path}. OS Error: {e}")
+
+    # Create an empty file if the download fails
+    try:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "wb") as f:
+            pass  # Create an empty file
+        print(f"Created an empty file at {output_path}")
+        return output_path
+    except OSError as e:
+        print(f"Failed to create an empty file at {output_path}. OS Error: {e}")
+        return ""
 
 
-def select_css(html_css_dir):
+def static_relative(path):
     """
-    Select CSS file with the website's template.
-
-    :param html_css_dir: The directory to save the CSS stylesheet.
-    :return: Returns a list of CSS files to be imported.
+    Get the relative path after "_static" in a posix style.
+    :param path: The original path.
+    :return: The relative path after "_static" in a posix style.
     """
-    ret = ""
-    common_css = "css/eprosima-furo.css"
-
-    if download_css(html_css_dir):
-        print("Appliying CSS style file: {}".format(common_css))
-        ret = common_css
-
-    return ret
+    if not path:
+        return ""
+    parts = path.split(os.path.sep)
+    if "_static" in parts:
+        idx = len(parts) - 1 - parts[::-1].index("_static")
+        rel_parts = parts[idx + 1 :]
+        return "/".join(rel_parts) if rel_parts else ""
+    return path
 
 
 script_path = os.path.dirname(os.path.abspath(__file__))
@@ -330,7 +321,16 @@ html_theme_options.update(download_json())
 
 html_use_smartypants = True
 
-html_css_files = [select_css(script_path)]
+# The CSS files referenced here should have a path relative to the _static folder.
+# We use static_relative(download_file(...)) to ensure the resulting paths are relative to "_static".
+html_css_files = [
+    static_relative(
+        download_file(
+            "https://raw.githubusercontent.com/eProsima/all-docs/master/source/_static/css/eprosima-furo.css",
+            "{}/_static/css/eprosima-furo.css".format(script_path),
+        )
+    )
+]
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.3.x 3.2.x 2.14.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/ShapesDemo#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo docs developers must also refer to the internal Redmine task. -->
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
