### PR TITLE
[23468] Updates after 3.3.1 EOL

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
     In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
     Please uncomment following line, adjusting the corresponding target branches for the backport.
 -->
-<!-- @Mergifyio backport 3.4.x 3.3.x 3.2.x 2.14.x -->
+<!-- @Mergifyio backport 3.4.x 3.2.x 2.14.x -->
 
 <!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
 <!-- Fixes #(issue) -->

--- a/docs/notes/previous_versions/previous_versions.rst
+++ b/docs/notes/previous_versions/previous_versions.rst
@@ -3,6 +3,12 @@
 Previous end-of-life versions
 =============================
 
+Version 3.3 (EOL)
+-----------------
+
+.. include:: v3.3.1.rst
+.. include:: v3.3.0.rst
+
 Version 3.1 (EOL)
 -----------------
 

--- a/docs/notes/previous_versions/supported_versions.rst
+++ b/docs/notes/previous_versions/supported_versions.rst
@@ -8,11 +8,6 @@ Version 3.4
 
 .. include:: v3.4.0.rst
 
-Version 3.3
------------
-
-.. include:: v3.3.0.rst
-
 Version 3.2
 -----------
 

--- a/docs/notes/previous_versions/v3.3.0.rst
+++ b/docs/notes/previous_versions/v3.3.0.rst
@@ -1,5 +1,5 @@
-Version 3.3.0
-^^^^^^^^^^^^^
+Version 3.3.0 (EOL)
+^^^^^^^^^^^^^^^^^^^
 
 This release includes the following **improvements**:
 

--- a/docs/notes/previous_versions/v3.3.1.rst
+++ b/docs/notes/previous_versions/v3.3.1.rst
@@ -1,0 +1,11 @@
+Version 3.3.1 (EOL)
+^^^^^^^^^^^^^^^^^^^
+
+This release includes the following **improvements**:
+
+#. Regenerate types with Fast DDS Gen 4.1.1
+#. Support for Fast DDS v3.3.1
+
+It also includes the following CI improvements:
+
+#. Removed mirror, nightly, weekly and minor changes


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.4.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/ShapesDemo#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo docs developers must also refer to the internal Redmine task. -->
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
