### PR TITLE
Add release notes of 3.5.0

### DIFF
--- a/docs/notes/notes.rst
+++ b/docs/notes/notes.rst
@@ -1,8 +1,11 @@
 .. _release_notes:
 
-Version 3.4.1 (latest)
+Version 3.5.0 (latest)
 ======================
 
 This release includes the following **improvements**:
 
-#. Support for Fast DDS v3.4.1
+#. Support for Fast DDS 3.5.0
+#. Upgrade from `Qt5` to `Qt6`
+#. Update after 3.3.1
+#. Regenerate code with Fast DDS Gen v4.3.0

--- a/docs/notes/previous_versions/supported_versions.rst
+++ b/docs/notes/previous_versions/supported_versions.rst
@@ -3,9 +3,16 @@
 Supported versions
 ==================
 
+Version 3.5
+-----------
+
+.. include:: v3.5.0.rst
+
 Version 3.4
 -----------
 
+.. include:: v3.4.2.rst
+.. include:: v3.4.1.rst
 .. include:: v3.4.0.rst
 
 Version 3.2

--- a/docs/notes/previous_versions/v3.4.1.rst
+++ b/docs/notes/previous_versions/v3.4.1.rst
@@ -1,0 +1,6 @@
+Version 3.4.1
+^^^^^^^^^^^^^
+
+This release includes the following **improvements**:
+
+#. Support for Fast DDS v3.4.1

--- a/docs/notes/previous_versions/v3.4.2.rst
+++ b/docs/notes/previous_versions/v3.4.2.rst
@@ -1,0 +1,6 @@
+Version 3.4.2
+^^^^^^^^^^^^^
+
+This patch release includes the following CI improvements:
+
+* Updates on 3.4.x after branchout of 3.5.x


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.4.x 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/ShapesDemo#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo docs developers must also refer to the internal Redmine task. -->
- [ ] Documentation tests pass locally.
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
