### PR TITLE
[#25465] Added Support multi-select endpoint deletion documentation

### DIFF
--- a/docs/first_steps/first_steps.rst
+++ b/docs/first_steps/first_steps.rst
@@ -230,10 +230,17 @@ An example of this legend is shown in the following figure.
    :align: center
 
 This table can be used to remove endpoints.
-Two methods are provided:
+Multiple endpoints can be selected at once using standard selection controls
+(``Ctrl+Click`` to toggle individual rows, ``Shift+Click`` to select a range).
 
-- Right click in an endpoint: An option to remove the endpoint is shown.
-- Pressing the delete button when the endpoint is selected.
+Two methods are provided to delete the selected endpoint(s):
+
+- **Right-click context menu:** Right-clicking on an endpoint row shows a *Delete Endpoint* option.
+  If the right-clicked row is not already part of the current selection, it becomes the sole selected row before
+  the menu appears.
+  If one or more rows are already selected and the right-clicked row is among them, the entire selection is
+  deleted when the option is chosen.
+- **Delete key:** Pressing the ``Delete`` key removes all currently selected endpoints at once.
 
 The output tab shows the output log messages.
 An example of the output tab is shown in the figure below.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR improves endpoint management in the Qt UI by allowing multiple endpoints to be selected and removed in one action.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/ShapesDemo#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. ShapesDemo docs developers must also refer to the internal Redmine task. -->
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
